### PR TITLE
Fixing an issue with running bin/console scheduler: while previous is still running.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+# Created by .ignore support plugin (hsz.mobi)

--- a/Command/ExecuteTasksCommand.php
+++ b/Command/ExecuteTasksCommand.php
@@ -28,10 +28,13 @@ class ExecuteTasksCommand extends ContainerAwareCommand {
         $output->writeln($count . ' Scheduled task' . ($count > 1 ? 's' : '') . ' identified.');
         foreach ($results as $taskId => $taskExecution) {
             if ($taskExecution instanceof TaskExecutionInterface) {
-                if ($taskExecution->getStatus() == TaskExecutionInterface::STATUS_SUCCESS)
+                if ($taskExecution->getStatus() == TaskExecutionInterface::STATUS_SUCCESS) {
                     $output->writeln('<info>Task \'' . $taskId . '\' was executed and was successful.</info>');
-                else
+                } else if ($taskExecution->getStatus() == TaskExecutionInterface::STATUS_IN_PROGRESS) {
+                    throw new \RuntimeException("Task should no longer be in progress");
+                } else {
                     $output->writeln('<error>Task \'' . $taskId . '\' was executed and was not successful.</error>');
+                }
             } else {
                 $output->writeln('Task \'' . $taskId . '\' was not executed.');
             }

--- a/Interfaces/ScheduleRunnerInterface.php
+++ b/Interfaces/ScheduleRunnerInterface.php
@@ -2,8 +2,6 @@
 
 namespace TDM\SchedulerBundle\Interfaces;
 
-use TDM\SchedulerBundle\Interfaces\ScheduledTaskInterface;
-
 /**
  *
  * @author wpigott

--- a/Interfaces/ScheduledTaskInterface.php
+++ b/Interfaces/ScheduledTaskInterface.php
@@ -2,7 +2,6 @@
 
 namespace TDM\SchedulerBundle\Interfaces;
 
-use TDM\SchedulerBundle\Interfaces\TaskExecutionInterface;
 use \DateTime;
 
 /**

--- a/Interfaces/TaskExecutionInterface.php
+++ b/Interfaces/TaskExecutionInterface.php
@@ -12,6 +12,7 @@ interface TaskExecutionInterface {
     
     const STATUS_FAILED = 'FAILED';
     const STATUS_SUCCESS = 'SUCCESS';
+    const STATUS_IN_PROGRESS = 'IN_PROGRESS';
 
     public function getId();
 

--- a/Model/ScheduleRunner.php
+++ b/Model/ScheduleRunner.php
@@ -30,7 +30,7 @@ class ScheduleRunner implements ScheduleRunnerInterface {
     }
 
     /**
-     * 
+     *
      * @return ObjectManager
      */
     protected function getObjectManager() {
@@ -38,21 +38,33 @@ class ScheduleRunner implements ScheduleRunnerInterface {
     }
 
     /**
-     * 
+     *
      * @return TaskExecutionRepositoryInterface
      */
     protected function getTaskExecutionRepository() {
         return $this->getObjectManager()->getRepository('TDMSchedulerBundle:TaskExecution');
     }
 
+    /**
+     * Changing the execution so that only one task is executed.
+     * @return array
+     */
     public function execute() {
-        $tasks = array();
+        $tasks = [];
+        $alreadyExecuted = false;
         foreach ($this->services as $serviceId => $service) {
             $tasks[$serviceId] = FALSE;
             try {
-                $tasks[$serviceId] = $this->executeTask($serviceId, $service);
-                if ($tasks[$serviceId] instanceof TaskExecutionInterface)
+                if ($alreadyExecuted) {
+                    continue;
+                }
+                $execution = $tasks[$serviceId] = $this->executeTask($serviceId, $service);
+                if ($execution instanceof TaskExecutionInterface) {
+                    $alreadyExecuted = true;
+                }
+                if ($tasks[$serviceId] instanceof TaskExecutionInterface) {
                     $this->getObjectManager()->flush();
+                }
             } catch (SchedulerException $e) {
                 continue;
             }
@@ -61,7 +73,7 @@ class ScheduleRunner implements ScheduleRunnerInterface {
     }
 
     /**
-     * 
+     *
      * @param string $serviceId
      * @param ScheduledTaskInterface $service
      * @return TaskExecutionInterface|boolean
@@ -87,7 +99,7 @@ class ScheduleRunner implements ScheduleRunnerInterface {
     }
 
     /**
-     * 
+     *
      * @return TaskExecutionInterface
      */
     protected function makeTaskExecution() {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/mongodb-odm": ">=1.0.0-BETA8"
     },
     "require-dev": {
-        "doctrine/mongodb-odm-bundle": "*"        
+        "doctrine/mongodb-odm-bundle": "*"
     },
     "autoload": {
         "psr-0": { "TDM\\SchedulerBundle": "" }
@@ -26,7 +26,7 @@
     "target-dir": "TDM/SchedulerBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev"
+            "dev-master": "0.1-slayful-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "target-dir": "TDM/SchedulerBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-slayful-dev"
+            "dev-slayful": "0.1-dev"
         }
     }
 }


### PR DESCRIPTION
Let's say Scheduler is run from cron every minute. We've got a task FetchUsers that should execute every 10 minutes and can run up to 5 minutes. On first Scheduler execution it starts FetchUsers task.
After 1 minute Scheduler is run again from cron and runs a second FetchUsers task even though it should be run 9 minutes later.

This occurs because in current implementation, the execution time is saved only after task completion. The second Scheduler execution still has no idea that the task has been run since it is still in progress.

This pull request stores the information that task has been run before its execution and introduces IN_PROGRESS task execution state.